### PR TITLE
Update msg when theme subfolder is not available

### DIFF
--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -63,7 +63,8 @@ module Jekyll
       # However, symlinks are allowed to point to other directories within the theme.
       Jekyll.sanitized_path(root, File.realpath(Jekyll.sanitized_path(root, folder.to_s)))
     rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP
-      Jekyll.logger.warn "Invalid theme folder:", folder
+      Jekyll.logger.warn "Path '#{folder}' does not exist, is not accessible "\
+        "or includes a symbolic link loop"
       nil
     end
 


### PR DESCRIPTION
Now the warning message is shown as:

```
Path '_sass' does not exist, is not accessible or includes a symbolic link loop 
```

If this can be downgraded to a `debug` level message please let me know to update it.

Fixes #7630

cc: @ashmaroli 